### PR TITLE
Correcting the basic dimension and argument mismatch issues to make the code simply be able to run. 

### DIFF
--- a/Utils/solveUV.m
+++ b/Utils/solveUV.m
@@ -18,7 +18,7 @@ else
     FT= NUFFT(ktraj/N,1,0,0,[N,N]);
     Atb = Atb_UV(FT,kdata,V,csm,N,false);
     Reg = @(x) reshape(reshape(x,[N*N,nbasis])*SBasis,[N*N*nbasis,1]);
-    AtA = @(x) AtA_UV(FT,x,V,csm,nSamplesPerFrame)+Reg(x);
+    AtA = @(x) AtA_UV(FT,x,V,csm,N,nSamplesPerFrame)+Reg(x);
 end
 
 x = pcg(AtA,Atb(:),1e-5,nIterations);

--- a/spiralStorm_iterative.m
+++ b/spiralStorm_iterative.m
@@ -9,7 +9,7 @@ addpath(genpath('./gpuNUFFT'));
 spiralsToDelete=100;
 ninterleavesPerFrame=5;
 N = 340;
-nChannelsToChoose=8;
+nChannelsToChoose=4;
 numFramesToKeep = 500;
 useGPU = 1;
 SHRINK_FACTOR = 1.0;
@@ -26,6 +26,7 @@ eig_csm=0.01;
 % % ============================================================== 
 load('./../series11.mat'); 
 kdata=kdata(:,:,:,1); % Fourth Slice Data
+kdata = permute(kdata,[1,3,2]);
 kdata=kdata/max(abs(kdata(:)));
 
  %% =========================================


### PR DESCRIPTION
Guessing from the number of data dimensions, the kdata that is loaded from the series11.mat dataset has 4 channels with 7500 spirals. However, in the current version, nChannelsToChoose is set to 8, the numberSpirals = 7500, and nCh = 4. 
In addition, solveUV function fails since AtA_UV function gets wrong arguments.
The problem is even after these fixes, the result coming out is not satisfactory. 